### PR TITLE
bumped actions/upload-artifact to version 7.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Crate Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -105,7 +105,7 @@ jobs:
       - name: test
         run: cargo llvm-cov -v -p asset-importer-rs-core --lcov --output-path lcov-core.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-core
           path: lcov-core.info
@@ -130,7 +130,7 @@ jobs:
       - name: test
         run: cargo llvm-cov -v -p asset-importer-rs-scene --lcov --output-path lcov-scene.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-scene
           path: lcov-scene.info
@@ -155,7 +155,7 @@ jobs:
       - name: test
         run: cargo llvm-cov -v -p asset-importer-rs-post-process --lcov --output-path lcov-post-process.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-post-process
           path: lcov-post-process.info
@@ -194,7 +194,7 @@ jobs:
             cargo llvm-cov -v --no-default-features -p asset-importer-rs-gltf --lcov --output-path lcov-gltf-${{ matrix.use_default_features }}.info
           fi
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-gltf-${{ matrix.use_default_features }}
           path: lcov-gltf-${{ matrix.use_default_features }}.info
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ['default', 'minimal']
+        features: ["default", "minimal"]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -233,7 +233,7 @@ jobs:
         env:
           FEATURES: ${{ matrix.features }}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-gltf-integration-${{ matrix.features }}
           path: lcov-gltf-integration-${{ matrix.features }}.info
@@ -272,7 +272,7 @@ jobs:
             cargo llvm-cov -v --no-default-features -p asset-importer-rs-gltf-v1 --lcov --output-path lcov-gltf-v1-${{ matrix.use_default_features }}.info
           fi
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-gltf-v1-${{ matrix.use_default_features }}
           path: lcov-gltf-v1-${{ matrix.use_default_features }}.info
@@ -286,7 +286,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ['minimal', 'default', 'extras']
+        features: ["minimal", "default", "extras"]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -305,7 +305,7 @@ jobs:
         env:
           FEATURES: ${{ matrix.features }}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-gltf-v1-integration-${{ matrix.features }}
           path: lcov-gltf-v1-integration-${{ matrix.features }}.info
@@ -330,7 +330,7 @@ jobs:
       - name: test crate
         run: cargo llvm-cov -v -p asset-importer-rs-obj --lcov --output-path lcov-obj.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-obj
           path: lcov-obj.info
@@ -344,7 +344,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ['minimal', 'default', 'extras']
+        features: ["minimal", "default", "extras"]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -363,7 +363,7 @@ jobs:
         env:
           FEATURES: ${{ matrix.features }}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-obj-integration-${{ matrix.features }}
           path: lcov-obj-integration-${{ matrix.features }}.info
@@ -388,7 +388,7 @@ jobs:
       - name: test crate
         run: cargo llvm-cov -v -p fbxscii --lcov --output-path lcov-fbxscii.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-fbxscii
           path: lcov-fbxscii.info
@@ -413,7 +413,7 @@ jobs:
       - name: test crate
         run: cargo llvm-cov -v -p fbx-dom --lcov --output-path lcov-fbx-dom.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-fbx-dom
           path: lcov-fbx-dom.info
@@ -438,7 +438,7 @@ jobs:
       - name: test
         run: cargo llvm-cov -v -p gltf-v1 --lcov --output-path lcov-gltf-v1.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-gltf-v1
           path: lcov-gltf-v1.info
@@ -463,7 +463,7 @@ jobs:
       - name: test
         run: cargo llvm-cov -v -p gltf-v1-json --lcov --output-path lcov-gltf-v1-json.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-gltf-v1-json
           path: lcov-gltf-v1-json.info
@@ -488,7 +488,7 @@ jobs:
       - name: test
         run: cargo llvm-cov -v -p gltf-v1-derive --lcov --output-path lcov-gltf-v1-derive.info
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-gltf-v1-derive
           path: lcov-gltf-v1-derive.info
@@ -517,7 +517,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@dbd64b376a77edb5c67164dc7b5383735171cf97 # cargo-llvm-cov
       - name: Download all coverage artifacts
@@ -539,4 +539,3 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-


### PR DESCRIPTION
## Summary
looking over github workflows  as part of #45  

I want to separate things I see, into small  PR's 

 to keep the review process focused on singular issues

**Our version of node is out of date**
```
[Test GLTF 2.0 Format (true)](https://github.com/crazyjackel/asset-importer-rs/actions/runs/30998519829/job/92290160979#step:17:2)
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5, actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

## Changes
  node 20 is deprecated, updating here will remove any unwanted side-effects from outdated unmaintained packages.

  No breaking changes --

## Checklist
- [x] Code follows project conventions
- [ n/a] Tests have been added/updated
- [ n/a] Documentation has been updated (if necessary)
- [x] Ready for review




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test and code-quality workflows for improved configuration consistency.
  * Upgraded coverage report artifact handling to the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->