### PR TITLE
fix: added type definition for coercion

### DIFF
--- a/crates/asset-importer-rs-gltf-v1/src/exporter/mesh.rs
+++ b/crates/asset-importer-rs-gltf-v1/src/exporter/mesh.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use asset_importer_rs_scene::{
     AI_MAX_NUMBER_OF_TEXTURECOORDS, AiPrimitiveType, AiQuaternion, AiScene, AiVector2D, AiVector3D,
+    ai_real_to_f32,
 };
 use gltf_v1::json::{
     Accessor, BufferView, Mesh, Root, StringIndex,
@@ -235,7 +236,7 @@ pub(crate) fn export_vector_2d(
     let mut data: Vec<u8> = Vec::with_capacity(vector_data.len() * 2 * 4);
     for vector in vector_data {
         for i in 0..2_usize {
-            let value = vector[i] as f32;
+            let value = ai_real_to_f32(vector[i]);
             if value < min[i] {
                 min[i] = value;
             }
@@ -281,7 +282,7 @@ pub(crate) fn export_vector_3d(
     let mut data: Vec<u8> = Vec::with_capacity(vector_data.len() * 3 * 4);
     for vector in vector_data {
         for i in 0..3_usize {
-            let value = vector[i] as f32;
+            let value = ai_real_to_f32(vector[i]);
             if value < min[i] {
                 min[i] = value;
             }
@@ -327,7 +328,7 @@ pub(crate) fn export_vector_4d(
     let mut data: Vec<u8> = Vec::with_capacity(vector_data.len() * 4 * 4);
     for vector in vector_data {
         for i in 0..4_usize {
-            let value = vector[i] as f32;
+            let value = ai_real_to_f32(vector[i]);
             if value < min[i] {
                 min[i] = value;
             }

--- a/crates/asset-importer-rs-gltf/src/exporter/mesh.rs
+++ b/crates/asset-importer-rs-gltf/src/exporter/mesh.rs
@@ -19,6 +19,7 @@ use gltf::{
 
 use asset_importer_rs_scene::{
     AiColor4D, AiMatrix4x4, AiPrimitiveType, AiQuaternion, AiReal, AiScene, AiVector2D, AiVector3D,
+    ai_real_to_f32,
 };
 use serde_json::{Number, Value};
 
@@ -470,7 +471,7 @@ impl AccessorExporter {
         for vector_base in vector_data {
             let matrix: [AiReal; 16] = vector_base.into();
             for (i, a) in matrix.iter().enumerate() {
-                let b = *a as f32;
+                let b = ai_real_to_f32(*a);
                 if b < min[i] {
                     min[i] = b;
                 }
@@ -551,7 +552,7 @@ impl AccessorExporter {
         let mut data: Vec<u8> = Vec::with_capacity(vector_data.len() * 4 * 4);
         for vector_base in vector_data {
             for vector in vector_base {
-                let a = *vector as f32;
+                let a = ai_real_to_f32(*vector);
                 if a < min_x {
                     min_x = a;
                 }

--- a/crates/asset-importer-rs-gltf/src/exporter/mesh.rs
+++ b/crates/asset-importer-rs-gltf/src/exporter/mesh.rs
@@ -478,10 +478,8 @@ impl AccessorExporter {
                 if b > max[i] {
                     max[i] = b;
                 }
+                data.extend_from_slice(&b.to_le_bytes());
             }
-
-            let vec: Vec<u8> = matrix.iter().flat_map(|x| x.to_le_bytes()).collect();
-            data.extend_from_slice(&vec);
         }
         let min = Some(Value::Array(vec![
             Value::Number(Number::from_f64(min[0] as f64).unwrap()),
@@ -734,8 +732,8 @@ impl AccessorExporter {
                 max_y = vector.y;
             }
 
-            data.extend_from_slice(&vector.x.to_le_bytes());
-            data.extend_from_slice(&vector.y.to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.x).to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.y).to_le_bytes());
         }
         let min = Some(Value::Array(vec![
             Value::Number(Number::from_f64(min_x as f64).unwrap()),
@@ -793,9 +791,9 @@ impl AccessorExporter {
                 max_z = vector.z;
             }
 
-            data.extend_from_slice(&vector.x.to_le_bytes());
-            data.extend_from_slice(&vector.y.to_le_bytes());
-            data.extend_from_slice(&vector.z.to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.x).to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.y).to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.z).to_le_bytes());
         }
         let min = Some(Value::Array(vec![
             Value::Number(Number::from_f64(min_x as f64).unwrap()),
@@ -863,10 +861,10 @@ impl AccessorExporter {
                 max_w = vector.w;
             }
 
-            data.extend_from_slice(&vector.x.to_le_bytes());
-            data.extend_from_slice(&vector.y.to_le_bytes());
-            data.extend_from_slice(&vector.z.to_le_bytes());
-            data.extend_from_slice(&vector.w.to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.x).to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.y).to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.z).to_le_bytes());
+            data.extend_from_slice(&ai_real_to_f32(vector.w).to_le_bytes());
         }
         let min = Some(Value::Array(vec![
             Value::Number(Number::from_f64(min_x as f64).unwrap()),

--- a/crates/asset-importer-rs-gltf/src/exporter/node.rs
+++ b/crates/asset-importer-rs-gltf/src/exporter/node.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use gltf::json::{Index, Node, Root, scene::UnitQuaternion};
 
-use asset_importer_rs_scene::{AiReal, AiScene};
+use asset_importer_rs_scene::{AiReal, AiScene, ai_real_to_f32};
 
 use crate::exporter::error::Gltf2ExportError;
 
@@ -40,14 +40,14 @@ impl Gltf2Exporter {
                 if use_translate_rotate_scale {
                     let decompose = ai_node.transformation.clone().decompose();
                     let translation: [AiReal; 3] = decompose.translation.into();
-                    node.translation = Some(translation.map(|x| x as f32));
+                    node.translation = Some(translation.map(ai_real_to_f32));
                     let rotation: [AiReal; 4] = decompose.rotation.into();
-                    node.rotation = Some(UnitQuaternion(rotation.map(|x| x as f32)));
+                    node.rotation = Some(UnitQuaternion(rotation.map(ai_real_to_f32)));
                     let scale: [AiReal; 3] = decompose.scale.into();
-                    node.scale = Some(scale.map(|x| x as f32));
+                    node.scale = Some(scale.map(ai_real_to_f32));
                 } else {
                     let transform_array: [AiReal; 16] = ai_node.transformation.clone().into();
-                    node.matrix = Some(transform_array.map(|x| x as f32));
+                    node.matrix = Some(transform_array.map(ai_real_to_f32));
                 }
             }
 

--- a/crates/asset-importer-rs-scene/src/type_def.rs
+++ b/crates/asset-importer-rs-scene/src/type_def.rs
@@ -14,6 +14,11 @@ pub mod base_types {
     pub const fn degrees_to_radians(degrees: AiReal) -> AiReal {
         degrees * 0.017_453_292_f64
     }
+
+    #[inline]
+    pub fn ai_real_to_f32(value: AiReal) -> f32 {
+        value as f32
+    }
 }
 #[cfg(not(feature = "double_precision"))]
 pub mod base_types {
@@ -31,6 +36,11 @@ pub mod base_types {
 
     pub const fn degrees_to_radians(degrees: AiReal) -> AiReal {
         degrees * 0.017_453_292_f32
+    }
+
+    #[inline]
+    pub fn ai_real_to_f32(value: AiReal) -> f32 {
+        value
     }
 }
 


### PR DESCRIPTION
## Summary
AiReal in double precision mode overwrites too many bytes or otherwise has coercions that are prone to being cleared by a linter. Updating to use an inline function for coercion and solving double precision bugs.

## Changes
- Improved consistency when exporting mesh and scene data across single- and double-precision configurations.
- Enhanced conversion of vectors, matrices, translations, rotations, scales, and bounds to supported output formats.
- Reduced the risk of precision-related inconsistencies in exported assets.

## Checklist
- [X] Code follows project conventions
- [X] Tests have been added/updated
- [X] Documentation has been updated (if necessary)
- [X] Ready for review
