### PR TITLE
Now uniformly wrapping tests in a mod tests.

### DIFF
--- a/crates/asset-importer-rs-gltf-v1/src/importer/material.rs
+++ b/crates/asset-importer-rs-gltf-v1/src/importer/material.rs
@@ -179,9 +179,13 @@ impl GltfImporter {
     }
 }
 
-#[test]
-fn test_gltf_material_import() {
-    let gltf_data = r#"
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    #[test]
+    fn test_gltf_material_import() {
+        let gltf_data = r#"
     {
         "materials": {
             "m0Avocado_M-fx": {
@@ -275,9 +279,10 @@ fn test_gltf_material_import() {
             }
         }
     }"#;
-    let scene = serde_json::from_str(gltf_data).unwrap();
-    let document = Document::from_json_without_validation(scene);
-    let (materials, _) =
-        GltfImporter::import_embedded_materials(&document, &HashMap::new()).unwrap();
-    assert_eq!(1, materials.len())
+        let scene = serde_json::from_str(gltf_data).unwrap();
+        let document = Document::from_json_without_validation(scene);
+        let (materials, _) =
+            GltfImporter::import_embedded_materials(&document, &HashMap::new()).unwrap();
+        assert_eq!(1, materials.len())
+    }
 }

--- a/crates/asset-importer-rs-gltf-v1/src/importer/texture.rs
+++ b/crates/asset-importer-rs-gltf-v1/src/importer/texture.rs
@@ -126,12 +126,16 @@ fn get_texels(data: &gltf_v1::image::Data) -> Vec<AiTexel> {
     texels
 }
 
-#[test]
-fn test_gltf_texture_import() {
-    let binding = std::env::current_dir().expect("Failed to get the current executable path");
-    let exe_path = binding.as_path();
+#[cfg(test)]
+mod tests {
 
-    let gltf_data = r#"{
+    use super::*;
+    #[test]
+    fn test_gltf_texture_import() {
+        let binding = std::env::current_dir().expect("Failed to get the current executable path");
+        let exe_path = binding.as_path();
+
+        let gltf_data = r#"{
             "images": {
                 "UnicodeTexture": {
                     "name": "UnicodeTexture",
@@ -139,10 +143,11 @@ fn test_gltf_texture_import() {
                 }
             }
         }"#;
-    let scene = serde_json::from_str(gltf_data).unwrap();
-    let document = Document::from_json_without_validation(scene);
-    let (embedded_textures, _tex_ids) =
-        GltfImporter::import_embedded_textures(&document, Some(exe_path), &IndexMap::new())
-            .unwrap();
-    assert_eq!(1, embedded_textures.len());
+        let scene = serde_json::from_str(gltf_data).unwrap();
+        let document = Document::from_json_without_validation(scene);
+        let (embedded_textures, _tex_ids) =
+            GltfImporter::import_embedded_textures(&document, Some(exe_path), &IndexMap::new())
+                .unwrap();
+        assert_eq!(1, embedded_textures.len());
+    }
 }

--- a/crates/asset-importer-rs-obj/tests/importer.rs
+++ b/crates/asset-importer-rs-obj/tests/importer.rs
@@ -3,12 +3,17 @@ use std::path::Path;
 use asset_importer_rs_core::AiImporterExt;
 use asset_importer_rs_obj::ObjImporter;
 
-#[test]
-fn test_importer_obj() {
-    let importer = ObjImporter::new();
-    let path = Path::new("assets/spider.obj");
-    assert!(path.exists(), "path does not exist");
-    let scene = importer.read_file_default(path);
-    assert!(scene.is_ok(), "error: {}", scene.err().unwrap());
-    assert_eq!(scene.unwrap().name, "spider");
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    #[test]
+    fn test_importer_obj() {
+        let importer = ObjImporter::new();
+        let path = Path::new("assets/spider.obj");
+        assert!(path.exists(), "path does not exist");
+        let scene = importer.read_file_default(path);
+        assert!(scene.is_ok(), "error: {}", scene.err().unwrap());
+        assert_eq!(scene.unwrap().name, "spider");
+    }
 }

--- a/crates/asset-importer-rs-scene/src/camera.rs
+++ b/crates/asset-importer-rs-scene/src/camera.rs
@@ -99,33 +99,39 @@ impl AiCamera {
     }
 }
 
-#[test]
-fn test_get_camera_matrix() {
-    let camera = AiCamera {
-        position: AiVector3D::new(0.0, 0.0, 5.0),
-        look_vec: AiVector3D::new(0.0, 0.0, -1.0),
-        up_vec: AiVector3D::new(0.0, 1.0, 0.0),
-        ..Default::default()
-    };
+#[cfg(test)]
+mod tests {
 
-    let view_matrix = camera.get_camera_matrix();
-    let base_matrix = AiMatrix4x4 {
-        a1: -1.0,
-        a2: 0.0,
-        a3: 0.0,
-        a4: 0.0,
-        b1: 0.0,
-        b2: 1.0,
-        b3: 0.0,
-        b4: 0.0,
-        c1: 0.0,
-        c2: 0.0,
-        c3: -1.0,
-        c4: 5.0,
-        d1: 0.0,
-        d2: 0.0,
-        d3: 0.0,
-        d4: 1.0,
-    };
-    assert_eq!(base_matrix, view_matrix);
+    use super::*;
+
+    #[test]
+    fn test_get_camera_matrix() {
+        let camera = AiCamera {
+            position: AiVector3D::new(0.0, 0.0, 5.0),
+            look_vec: AiVector3D::new(0.0, 0.0, -1.0),
+            up_vec: AiVector3D::new(0.0, 1.0, 0.0),
+            ..Default::default()
+        };
+
+        let view_matrix = camera.get_camera_matrix();
+        let base_matrix = AiMatrix4x4 {
+            a1: -1.0,
+            a2: 0.0,
+            a3: 0.0,
+            a4: 0.0,
+            b1: 0.0,
+            b2: 1.0,
+            b3: 0.0,
+            b4: 0.0,
+            c1: 0.0,
+            c2: 0.0,
+            c3: -1.0,
+            c4: 5.0,
+            d1: 0.0,
+            d2: 0.0,
+            d3: 0.0,
+            d4: 1.0,
+        };
+        assert_eq!(base_matrix, view_matrix);
+    }
 }

--- a/crates/asset-importer-rs-scene/src/material.rs
+++ b/crates/asset-importer-rs-scene/src/material.rs
@@ -621,6 +621,8 @@ impl AiMaterial {
         }
     }
 }
+
+#[cfg(test)]
 mod tests {
     /// Tests the code of get_real_vector's String | Buffer Match
     /// Check that strings made up of joined floats can be parsed successfully

--- a/crates/gltf-v1-json/src/accessor.rs
+++ b/crates/gltf-v1-json/src/accessor.rs
@@ -235,9 +235,14 @@ pub struct Accessor {
     pub name: Option<String>,
 }
 
-#[test]
-fn test_accessor_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_accessor_deserialize() {
+        let data = r#"{
             "bufferView" : "bufferViewWithVertices_id",
             "byteOffset" : 0,
             "byteStride" : 3,
@@ -254,14 +259,15 @@ fn test_accessor_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }
     "#;
-    let accessor: Result<Accessor, _> = serde_json::from_str(data);
-    let accessor_unwrap = accessor.unwrap();
-    println!("{}", serde_json::to_string(&accessor_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined accessor name".to_string()),
-        accessor_unwrap.name
-    );
+        let accessor: Result<Accessor, _> = serde_json::from_str(data);
+        let accessor_unwrap = accessor.unwrap();
+        println!("{}", serde_json::to_string(&accessor_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined accessor name".to_string()),
+            accessor_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/animation.rs
+++ b/crates/gltf-v1-json/src/animation.rs
@@ -176,9 +176,14 @@ pub struct Animation {
     pub name: Option<String>,
 }
 
-#[test]
-fn test_animation_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_animation_deserialize() {
+        let data = r#"{
             "channels": [
                 {
                     "sampler": "a_sampler",
@@ -192,7 +197,7 @@ fn test_animation_deserialize() {
                         },
                         "extras" : {
                             "Application specific" : "The extra object can contain any properties."
-                        }     
+                        }
                     },
                      "extensions" : {
                          "extension_name" : {
@@ -201,7 +206,7 @@ fn test_animation_deserialize() {
                      },
                     "extras" : {
                         "Application specific" : "The extra object can contain any properties."
-                    }     
+                    }
                 }
             ],
             "name": "user-defined animation name",
@@ -221,7 +226,7 @@ fn test_animation_deserialize() {
 		            },
                     "extras" : {
                         "Application specific" : "The extra object can contain any properties."
-                    }     
+                    }
                 }
             },
             "extensions" : {
@@ -231,13 +236,14 @@ fn test_animation_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let animation: Result<Animation, _> = serde_json::from_str(data);
-    let animation_unwrap = animation.unwrap();
-    println!("{}", serde_json::to_string(&animation_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined animation name".to_string()),
-        animation_unwrap.name
-    );
+        let animation: Result<Animation, _> = serde_json::from_str(data);
+        let animation_unwrap = animation.unwrap();
+        println!("{}", serde_json::to_string(&animation_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined animation name".to_string()),
+            animation_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/asset.rs
+++ b/crates/gltf-v1-json/src/asset.rs
@@ -22,9 +22,14 @@ pub struct Asset {
     pub version: String,
 }
 
-#[test]
-fn test_asset_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_asset_deserialize() {
+        let data = r#"{
         "copyright" : "(C) Copyright Khronos Group",
         "generator" : "collada2gltf@042d7d2a3782aaf6d86961d052fc53bea8b3e424",
         "premultipliedAlpha" : true,
@@ -33,7 +38,7 @@ fn test_asset_deserialize() {
             "version" : "1.0.3",
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }  
+            }
         },
         "version" : "1.0",
         "extensions" : {
@@ -43,13 +48,14 @@ fn test_asset_deserialize() {
         },
         "extras" : {
             "Application specific" : "The extra object can contain any properties."
-        }  
+        }
     }"#;
-    let asset: Result<Asset, _> = serde_json::from_str(data);
-    let asset_unwrap = asset.unwrap();
-    println!("{}", serde_json::to_string(&asset_unwrap).unwrap());
-    assert_eq!(
-        Some("(C) Copyright Khronos Group".to_string()),
-        asset_unwrap.copyright
-    );
+        let asset: Result<Asset, _> = serde_json::from_str(data);
+        let asset_unwrap = asset.unwrap();
+        println!("{}", serde_json::to_string(&asset_unwrap).unwrap());
+        assert_eq!(
+            Some("(C) Copyright Khronos Group".to_string()),
+            asset_unwrap.copyright
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/buffer.rs
+++ b/crates/gltf-v1-json/src/buffer.rs
@@ -190,9 +190,14 @@ fn default_byte_length() -> USize64 {
     0u64.into()
 }
 
-#[test]
-fn test_buffer_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_buffer_deserialize() {
+        let data = r#"{
             "uri": "vertices.bin",
             "byteLength": 1024,
             "name": "user-defined buffer name",
@@ -206,31 +211,31 @@ fn test_buffer_deserialize() {
                 "Application specific" : "The extra object can contain any properties."
             }
         }"#;
-    let buffer: Result<Buffer, _> = serde_json::from_str(data);
-    let buffer_unwrap = buffer.unwrap();
-    println!("{}", serde_json::to_string(&buffer_unwrap).unwrap());
-    assert_eq!("vertices.bin".to_string(), buffer_unwrap.uri);
-}
+        let buffer: Result<Buffer, _> = serde_json::from_str(data);
+        let buffer_unwrap = buffer.unwrap();
+        println!("{}", serde_json::to_string(&buffer_unwrap).unwrap());
+        assert_eq!("vertices.bin".to_string(), buffer_unwrap.uri);
+    }
 
-#[test]
-fn test_binary_buffer_deserialize() {
-    let data = r#"{
+    #[test]
+    fn test_binary_buffer_deserialize() {
+        let data = r#"{
             "type":"arraybuffer",
             "byteLength":1975367,
             "uri":"data:,"
         }"#;
-    let buffer: Result<Buffer, _> = serde_json::from_str(data);
-    let buffer_unwrap = buffer.unwrap();
-    println!("{}", serde_json::to_string(&buffer_unwrap).unwrap());
-    assert_eq!(
-        Some(Checked::Valid(BufferType::ArrayBuffer)),
-        buffer_unwrap.type_
-    );
-}
+        let buffer: Result<Buffer, _> = serde_json::from_str(data);
+        let buffer_unwrap = buffer.unwrap();
+        println!("{}", serde_json::to_string(&buffer_unwrap).unwrap());
+        assert_eq!(
+            Some(Checked::Valid(BufferType::ArrayBuffer)),
+            buffer_unwrap.type_
+        );
+    }
 
-#[test]
-fn test_buffer_view_deserialize() {
-    let data = r#"{
+    #[test]
+    fn test_buffer_view_deserialize() {
+        let data = r#"{
             "buffer" : "buffer_id",
             "byteLength": 76768,
             "byteOffset": 0,
@@ -245,11 +250,12 @@ fn test_buffer_view_deserialize() {
                 "Application specific" : "The extra object can contain any properties."
             }
         }"#;
-    let buffer_view: Result<BufferView, _> = serde_json::from_str(data);
-    let buffer_view_unwrap = buffer_view.unwrap();
-    println!("{}", serde_json::to_string(&buffer_view_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined name of bufferView with vertices".to_string()),
-        buffer_view_unwrap.name
-    );
+        let buffer_view: Result<BufferView, _> = serde_json::from_str(data);
+        let buffer_view_unwrap = buffer_view.unwrap();
+        println!("{}", serde_json::to_string(&buffer_view_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined name of bufferView with vertices".to_string()),
+            buffer_view_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/gltf.rs
+++ b/crates/gltf-v1-json/src/gltf.rs
@@ -178,9 +178,14 @@ impl_get!(Skin, skins);
 impl_get!(Texture, textures);
 impl_get!(Technique, techniques);
 
-#[test]
-fn test_gltf_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_gltf_deserialize() {
+        let data = r#"{
     "asset" : {
         "copyright" : "(C) Copyright Khronos Group",
         "generator" : "collada2gltf@042d7d2a3782aaf6d86961d052fc53bea8b3e424",
@@ -190,7 +195,7 @@ fn test_gltf_deserialize() {
             "version" : "1.0.3",
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }  
+            }
         },
         "version" : "1.0",
         "extensions" : {
@@ -200,13 +205,14 @@ fn test_gltf_deserialize() {
         },
         "extras" : {
             "Application specific" : "The extra object can contain any properties."
-        }  
+        }
     }
 }"#;
-    let gltf: Root = serde_json::from_str(data).unwrap();
-    println!("{}", serde_json::to_string(&gltf).unwrap());
-    assert_eq!(
-        &Some("(C) Copyright Khronos Group".to_string()),
-        &gltf.asset.unwrap().copyright
-    );
+        let gltf: Root = serde_json::from_str(data).unwrap();
+        println!("{}", serde_json::to_string(&gltf).unwrap());
+        assert_eq!(
+            &Some("(C) Copyright Khronos Group".to_string()),
+            &gltf.asset.unwrap().copyright
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/image.rs
+++ b/crates/gltf-v1-json/src/image.rs
@@ -12,9 +12,14 @@ pub struct Image {
     pub extensions: Option<extensions::image::Image>,
 }
 
-#[test]
-fn test_image_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_image_deserialize() {
+        let data = r#"{
             "name": "user-defined image name",
             "uri" : "image.png",
             "extensions" : {
@@ -26,11 +31,12 @@ fn test_image_deserialize() {
                 "Application specific" : "The extra object can contain any properties."
             }
         }"#;
-    let image: Result<Image, _> = serde_json::from_str(data);
-    let image_unwrap = image.unwrap();
-    println!("{}", serde_json::to_string(&image_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined image name".to_string()),
-        image_unwrap.name
-    );
+        let image: Result<Image, _> = serde_json::from_str(data);
+        let image_unwrap = image.unwrap();
+        println!("{}", serde_json::to_string(&image_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined image name".to_string()),
+            image_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/material.rs
+++ b/crates/gltf-v1-json/src/material.rs
@@ -1183,9 +1183,14 @@ pub struct Material {
     pub extensions: Option<extensions::material::Material>,
 }
 
-#[test]
-fn test_technique_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_technique_deserialize() {
+        let data = r#"{
             "name": "user-defined technique name",
             "parameters": {
                 "ambient": {
@@ -1313,17 +1318,18 @@ fn test_technique_deserialize() {
                 "Application specific" : "The extra object can contain any properties."
             }
         }"#;
-    let technique: Result<Technique, _> = serde_json::from_str(data);
-    let technique_unwrap = technique.unwrap();
-    println!("{}", serde_json::to_string(&technique_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined technique name".to_string()),
-        technique_unwrap.name
-    );
-}
-#[test]
-fn test_material_deserialize() {
-    let data = r#"{
+        let technique: Result<Technique, _> = serde_json::from_str(data);
+        let technique_unwrap = technique.unwrap();
+        println!("{}", serde_json::to_string(&technique_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined technique name".to_string()),
+            technique_unwrap.name
+        );
+    }
+
+    #[test]
+    fn test_material_deserialize() {
+        let data = r#"{
             "technique": "technique_id",
             "values": {
                 "ambient": [
@@ -1343,13 +1349,14 @@ fn test_material_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let material: Result<Material, _> = serde_json::from_str(data);
-    let material_unwrap = material.unwrap();
-    println!("{}", serde_json::to_string(&material_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined material name".to_string()),
-        material_unwrap.name
-    );
+        let material: Result<Material, _> = serde_json::from_str(data);
+        let material_unwrap = material.unwrap();
+        println!("{}", serde_json::to_string(&material_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined material name".to_string()),
+            material_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/mesh.rs
+++ b/crates/gltf-v1-json/src/mesh.rs
@@ -245,9 +245,14 @@ pub struct Mesh {
     pub name: Option<String>,
 }
 
-#[test]
-fn test_mesh_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_mesh_deserialize() {
+        let data = r#"{
             "name": "user-defined name of mesh",
             "primitives": [
                 {
@@ -266,7 +271,7 @@ fn test_mesh_deserialize() {
 		            },
                     "extras" : {
                         "Application specific" : "The extra object can contain any properties."
-                    }     
+                    }
                 }
             ],
             "extensions" : {
@@ -276,13 +281,14 @@ fn test_mesh_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let mesh: Result<Mesh, _> = serde_json::from_str(data);
-    let mesh_unwrap = mesh.unwrap();
-    println!("{}", serde_json::to_string(&mesh_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined name of mesh".to_string()),
-        mesh_unwrap.name
-    );
+        let mesh: Result<Mesh, _> = serde_json::from_str(data);
+        let mesh_unwrap = mesh.unwrap();
+        println!("{}", serde_json::to_string(&mesh_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined name of mesh".to_string()),
+            mesh_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/node.rs
+++ b/crates/gltf-v1-json/src/node.rs
@@ -36,9 +36,14 @@ pub struct Node {
     pub extensions: Option<extensions::node::Node>,
 }
 
-#[test]
-fn test_node_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_node_deserialize() {
+        let data = r#"{
             "children": [],
             "matrix": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ],
             "meshes": [
@@ -52,13 +57,14 @@ fn test_node_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let node: Result<Node, _> = serde_json::from_str(data);
-    let node_unwrap = node.unwrap();
-    println!("{}", serde_json::to_string(&node_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined name of meshes node".to_string()),
-        node_unwrap.name
-    );
+        let node: Result<Node, _> = serde_json::from_str(data);
+        let node_unwrap = node.unwrap();
+        println!("{}", serde_json::to_string(&node_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined name of meshes node".to_string()),
+            node_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/scene.rs
+++ b/crates/gltf-v1-json/src/scene.rs
@@ -13,9 +13,14 @@ pub struct Scene {
     pub name: Option<String>,
 }
 
-#[test]
-fn test_scene_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_scene_deserialize() {
+        let data = r#"{
             "name": "user-defined scene name",
             "nodes": [
                 "mesh_node_id",
@@ -30,11 +35,12 @@ fn test_scene_deserialize() {
                 "Application specific" : "The extra object can contain any properties."
             }
         }"#;
-    let scene: Result<Scene, _> = serde_json::from_str(data);
-    let scene_unwrap = scene.unwrap();
-    println!("{}", serde_json::to_string(&scene_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined scene name".to_string()),
-        scene_unwrap.name
-    );
+        let scene: Result<Scene, _> = serde_json::from_str(data);
+        let scene_unwrap = scene.unwrap();
+        println!("{}", serde_json::to_string(&scene_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined scene name".to_string()),
+            scene_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/shader.rs
+++ b/crates/gltf-v1-json/src/shader.rs
@@ -138,9 +138,13 @@ impl Program {
     }
 }
 
-#[test]
-fn test_program_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_program_deserialize() {
+        let data = r#"{
             "attributes": [
                 "a_normal",
                 "a_position"
@@ -155,20 +159,20 @@ fn test_program_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let program: Result<Program, _> = serde_json::from_str(data);
-    let program_unwrap = program.unwrap();
-    println!("{}", serde_json::to_string(&program_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined program name".to_string()),
-        program_unwrap.name
-    );
-}
+        let program: Result<Program, _> = serde_json::from_str(data);
+        let program_unwrap = program.unwrap();
+        println!("{}", serde_json::to_string(&program_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined program name".to_string()),
+            program_unwrap.name
+        );
+    }
 
-#[test]
-fn test_shader_deserialize() {
-    let data = r#"{
+    #[test]
+    fn test_shader_deserialize() {
+        let data = r#"{
             "name": "user-defined vertex shader name",
             "uri" : "vertexshader.glsl",
             "type": 35633,
@@ -181,11 +185,12 @@ fn test_shader_deserialize() {
                 "Application specific" : "The extra object can contain any properties."
             }
         }"#;
-    let shader: Result<Shader, _> = serde_json::from_str(data);
-    let shader_unwrap = shader.unwrap();
-    println!("{}", serde_json::to_string(&shader_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined vertex shader name".to_string()),
-        shader_unwrap.name
-    );
+        let shader: Result<Shader, _> = serde_json::from_str(data);
+        let shader_unwrap = shader.unwrap();
+        println!("{}", serde_json::to_string(&shader_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined vertex shader name".to_string()),
+            shader_unwrap.name
+        );
+    }
 }

--- a/crates/gltf-v1-json/src/skin.rs
+++ b/crates/gltf-v1-json/src/skin.rs
@@ -44,10 +44,14 @@ fn default_matrix() -> [f32; 16] {
         1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
     ]
 }
+#[cfg(test)]
+mod tests {
 
-#[test]
-fn test_skin_deserialize() {
-    let data = r#"{
+    use super::*;
+
+    #[test]
+    fn test_skin_deserialize() {
+        let data = r#"{
             "bindShapeMatrix": [
                 1,
                 0,
@@ -79,10 +83,11 @@ fn test_skin_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let skin: Result<Skin, _> = serde_json::from_str(data);
-    let skin_unwrap = skin.unwrap();
-    println!("{}", serde_json::to_string(&skin_unwrap).unwrap());
-    assert_eq!(Some("user-defined skin name".to_string()), skin_unwrap.name);
+        let skin: Result<Skin, _> = serde_json::from_str(data);
+        let skin_unwrap = skin.unwrap();
+        println!("{}", serde_json::to_string(&skin_unwrap).unwrap());
+        assert_eq!(Some("user-defined skin name".to_string()), skin_unwrap.name);
+    }
 }

--- a/crates/gltf-v1-json/src/texture.rs
+++ b/crates/gltf-v1-json/src/texture.rs
@@ -550,9 +550,14 @@ fn default_texture_type() -> Checked<TextureType> {
     Checked::Valid(TextureType::UnsignedByte)
 }
 
-#[test]
-fn test_sampler_deserialize() {
-    let data = r#"{
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_sampler_deserialize() {
+        let data = r#"{
             "magFilter": 9729,
             "minFilter": 9987,
             "name": "user-defined sampler name",
@@ -565,20 +570,20 @@ fn test_sampler_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let sampler: Result<Sampler, _> = serde_json::from_str(data);
-    let sampler_unwrap = sampler.unwrap();
-    println!("{}", serde_json::to_string(&sampler_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined sampler name".to_string()),
-        sampler_unwrap.name
-    );
-}
+        let sampler: Result<Sampler, _> = serde_json::from_str(data);
+        let sampler_unwrap = sampler.unwrap();
+        println!("{}", serde_json::to_string(&sampler_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined sampler name".to_string()),
+            sampler_unwrap.name
+        );
+    }
 
-#[test]
-fn test_texture_deserialize() {
-    let data = r#"{
+    #[test]
+    fn test_texture_deserialize() {
+        let data = r#"{
             "format": 6408,
             "internalFormat": 6408,
             "name": "user-defined texture name",
@@ -593,13 +598,14 @@ fn test_texture_deserialize() {
             },
             "extras" : {
                 "Application specific" : "The extra object can contain any properties."
-            }     
+            }
         }"#;
-    let texture: Result<Texture, _> = serde_json::from_str(data);
-    let texture_unwrap = texture.unwrap();
-    println!("{}", serde_json::to_string(&texture_unwrap).unwrap());
-    assert_eq!(
-        Some("user-defined texture name".to_string()),
-        texture_unwrap.name
-    );
+        let texture: Result<Texture, _> = serde_json::from_str(data);
+        let texture_unwrap = texture.unwrap();
+        println!("{}", serde_json::to_string(&texture_unwrap).unwrap());
+        assert_eq!(
+            Some("user-defined texture name".to_string()),
+            texture_unwrap.name
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Outside of integration tests the convention is to wrap the functions in a separate module.
This keeps functions out of release and development builds

[ integration test are found in a "tests" directory. ]

## Changes

I have made no functional changes... just wrapped test

```rust
#[cfg(test)]
mod tests {

    use super::*;

    #[test]
   fn test_a(){
     // .... 
   }
}
```

## Checklist
- [x] Code follows project conventions
- [x] Tests have been added/updated
- [n/a] Documentation has been updated (if necessary)
- [X] Ready for review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Organized importer and glTF validation tests to run only in test builds.
  - Preserved existing deserialization, serialization, camera, material, texture, and asset-import behavior.
  - Added coverage for importing textures with Unicode characters.
  - Standardized test formatting and structure for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->