### PR TITLE
cargo doc is not sufficient

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -24,7 +24,7 @@ jobs:
       - name: build
         run: cargo build -v --locked
       - name: test
-        run: cargo doc -v
+        run: cargo doc --workspace -v
 
   clippy:
     name: Lint Code

--- a/crates/fbxscii/src/parser.rs
+++ b/crates/fbxscii/src/parser.rs
@@ -438,7 +438,7 @@ impl ElementAttribute {
     /// returns one entry per direct child of the subtree root (child key paired with vector of leaf or nested
     /// subtree). If the subtree root index is invalid, returns an empty map.
     ///
-    /// If you only want the distinct and want to use less memory, use [get_children_distinct] instead.
+    /// If you only want the distinct and want to use less memory, use [ElementAttribute::get_children_distinct] instead.
     pub fn get_children(&self) -> HashMap<String, Vec<ElementAttribute>> {
         match self {
             ElementAttribute::Leaf(_) => HashMap::new(),
@@ -469,7 +469,7 @@ impl ElementAttribute {
     /// returns one entry per direct child of the subtree root (child key paired with leaf or nested
     /// subtree). If the subtree root index is invalid, returns an empty vector.
     ///
-    /// Some Element's might have multiple children with the same key, use [get_children] instead.
+    /// Some Element's might have multiple children with the same key, use [ElementAttribute::get_children] instead.
     pub fn get_children_distinct(&self) -> HashMap<String, ElementAttribute> {
         match self {
             ElementAttribute::Leaf(_) => HashMap::new(),


### PR DESCRIPTION
## Summary
Recently #69 fixed lints associated with cargo doc.  Adding --workspace exposes more lint failures.

## Changes
- No breaking changes.
- In doc comments use Fully Qualified Domain Name
- Also workflows/cargo.yml need to be fixed.
```bash
cargo doc --workspace -v
```


## Checklist
- [X] Code follows project conventions
- [n/a] Tests have been added/updated
- [X] Documentation has been updated (if necessary)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected API documentation links for child-element access methods, improving navigation and reference accuracy.

- **Tests**
  - Expanded documentation checks to cover the complete workspace, helping ensure documentation builds consistently across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->