### PR TITLE
Security: Restrict the GITHUB_TOKEN permissions.

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   test_doc:
+    permissions:
+      contents: read
     name: Run Documentation Tests
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +29,8 @@ jobs:
         run: cargo doc -v
 
   clippy:
+    permissions:
+      contents: read
     name: Lint Code
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +42,8 @@ jobs:
         run: cargo clippy --all-features
 
   rustfmt:
+    permissions:
+      contents: read
     name: Check Code Formatting
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

As reoprted by coderabbitai[bot] in issue #73

>This job checks out source and generates documentation. It does not need write access. The workflow has no permissions block, so the token uses repository or organization defaults. Add contents: read at job or workflow scope.

This the same argument applies to


Briefly describe the purpose of this PR and what it addresses.

## Changes
  No breaking changes 

## Checklist
- [X] Code follows project conventions
- [n/a] Tests have been added/updated
- [n/a] Documentation has been updated (if necessary)
- [X] Ready for review
